### PR TITLE
Bugfix of the rule `named-export`: failed when parse the code written in TypeScript #26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+## Bugfix
+* [#27](https://github.com/epaew/eslint-plugin-filenames-simple/pull/27) Fixed the behavior that ESLint execution fails
+when the lint target includes TypeScript notation and the rule `named-export` is enabled.
 
 # 0.3.0
 ## Features

--- a/docs/rules/named-export.md
+++ b/docs/rules/named-export.md
@@ -6,22 +6,22 @@ This rule checks the export name is same as filename.
 ## Examples
 ### Basic
 * module.js
-    ```js
+    ```javascript
     export const module = 1; // OK
     ```
 * module.js
-    ```js
+    ```javascript
     export const mod = 1; // NG: You can use `module` or `Module` as export name.
     ```
 
 * module.js
-    ```js
+    ```javascript
     // default export is ignored
     const module = 1;
     export default module;
     ```
 * modules.js
-    ```js
+    ```javascript
     // Multiple named exports are ignored too.
     const module1 = 1;
     const module2 = 2;
@@ -30,7 +30,7 @@ This rule checks the export name is same as filename.
 
 ### When the filename contains two or more words
 * my-class.js
-    ```js
+    ```javascript
     /*
      * When the filename is written in kebab-case, camelCase or PascalCase,
      * the export name can be written in `camelCase` or `PascalCase`
@@ -38,21 +38,41 @@ This rule checks the export name is same as filename.
     export class MyClass {}
     ```
 * myFunction.js
-    ```js
+    ```javascript
     export function myFunction() {} // `MyFunction()` is also OK.
     ```
 
 ### When the filename is `index.js` (`index.ts`)
 * src/rules/index.js
-    ```js
+    ```javascript
     // You can use parent directory name as export name.
     export const rules = {};
     ```
 * src/config/index.js
-    ```js
+    ```javascript
     // Multiple named export are ignored.
     export * from './all';
     export * from './recommended';
+    ```
+
+### You can also lint TypeScript notations
+* fruits.ts
+    ```typescript
+    export enum fruits {
+      orange = 'orange',
+      apple = 'apple',
+      banana = 'banana',
+    }
+    ```
+* identifier.ts
+    ```typescript
+    export interface Identifier {
+      name: string;
+    }
+    ```
+* class-expression.d.ts
+    ```typescript
+    export type ClassExpression = { id: Identifier }
     ```
 
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/node": "^14.0.5",
     "@typescript-eslint/eslint-plugin": "^3.0.2",
     "@typescript-eslint/parser": "^3.0.2",
+    "@typescript-eslint/typescript-estree": "^3.1.0",
     "eslint": "^7.1.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-filenames-simple": "file:.",

--- a/src/utils/estree-parser.ts
+++ b/src/utils/estree-parser.ts
@@ -1,0 +1,154 @@
+import * as ESTree from 'estree';
+import { TSESTree as TSTree } from '@typescript-eslint/typescript-estree';
+
+import '../utils/polyfill.node10';
+
+// types
+type Maybe<T> = T | undefined;
+
+export type DestructuringPattern = ESTree.Pattern | TSTree.DestructuringPattern;
+export type ExportDeclaration = ESTree.Declaration | TSTree.ExportDeclaration | null;
+export type ExportNamedDeclaration = ESTree.ExportNamedDeclaration | TSTree.ExportNamedDeclaration;
+export type ExportSpecifier = ESTree.ExportSpecifier | TSTree.ExportSpecifier;
+export type Identifier = ESTree.Identifier | TSTree.Identifier;
+export type Node = ESTree.Node | TSTree.Node;
+export type ObjectPattern = ESTree.ObjectPattern | TSTree.ObjectPattern;
+export type ObjectProperty = ESTree.AssignmentPattern | RestElement | TSTree.Property;
+export type Program = ESTree.Program | TSTree.Program;
+export type PropertyValue = TSTree.Property['value'];
+export type RestElement = ESTree.RestElement | TSTree.RestElement;
+export type Statement = ESTree.Statement | TSTree.Statement;
+export type VariableDeclaration = ESTree.VariableDeclaration | TSTree.VariableDeclaration;
+export type VariableDeclarator = ESTree.VariableDeclarator | TSTree.VariableDeclarator;
+
+// functions
+const getExportNamedDeclarationfromProgram = (node: Program): ExportNamedDeclaration[] =>
+  (node.body as Statement[]).filter(
+    n => n.type === 'ExportNamedDeclaration',
+  ) as ExportNamedDeclaration[];
+
+const getIdentifiersFromDeclarationOfExportNamedDeclaration = (
+  node: Maybe<ExportDeclaration>,
+): Identifier[] => {
+  if (!node) return [];
+
+  switch (node.type) {
+    case 'ClassDeclaration':
+    case 'ClassExpression':
+    case 'FunctionDeclaration':
+    case 'TSDeclareFunction':
+    case 'TSEnumDeclaration':
+    case 'TSInterfaceDeclaration':
+    case 'TSTypeAliasDeclaration':
+      return node.id ? [node.id] : [];
+    case 'TSModuleDeclaration':
+      return node.id.type === 'Identifier' ? [node.id] : [];
+    case 'VariableDeclaration':
+      return getIdentifiersFromVariableDeclaration(node);
+    default:
+      console.error(new Error(`UnknownDeclaration: ${node}`));
+      return [];
+  }
+};
+
+const getIdentifiersFromDestructuringPattern = (
+  node: DestructuringPattern | null,
+): Identifier[] => {
+  if (!node) return [];
+
+  switch (node.type) {
+    case 'ArrayPattern':
+      return (node.elements as DestructuringPattern[]).flatMap(e =>
+        getIdentifiersFromDestructuringPattern(e),
+      );
+    case 'AssignmentPattern':
+      return getIdentifiersFromDestructuringPattern(node.left);
+    case 'Identifier':
+      return [node];
+    case 'MemberExpression':
+      return []; // MemberExpression has no Identifier.
+    case 'ObjectPattern':
+      return (node.properties as ObjectProperty[]).flatMap(e =>
+        getIdentifiersFromObjectProperty(e),
+      );
+    case 'RestElement':
+      return getIdentifiersFromDestructuringPattern(node.argument);
+    default:
+      console.error(new Error(`UnknownDestructuringPattern: ${node}`));
+      return [];
+  }
+};
+
+const getIdentifiersFromObjectProperty = (node: ObjectProperty): Identifier[] => {
+  switch (node.type) {
+    case 'AssignmentPattern':
+    case 'RestElement':
+      return getIdentifiersFromDestructuringPattern(node);
+    case 'Property':
+      return getIdentifiersFromPropertyValue(node.value);
+    default:
+      console.error(new Error(`UnknownObjectProperty: ${node}`));
+      return [];
+  }
+};
+
+const getIdentifiersFromPropertyValue = (node: PropertyValue): Identifier[] => {
+  switch (node.type) {
+    case 'AssignmentPattern':
+      return getIdentifiersFromDestructuringPattern(node.left);
+    case 'Identifier':
+      return [node];
+    case 'ObjectPattern':
+      return (node.properties as ObjectProperty[]).flatMap(e =>
+        getIdentifiersFromObjectProperty(e),
+      );
+    default:
+      console.error(`Sorry, parser For Expression: ${node} is not implemented.`);
+      return [];
+  }
+};
+
+const getIdentifiersFromSpecifiersOfExportNamedDeclaration = (
+  nodes: ExportSpecifier[],
+): Identifier[] => nodes.map(n => n.exported);
+
+const getIdentifiersFromExportNamedDeclaration = (node: ExportNamedDeclaration): Identifier[] => [
+  ...getIdentifiersFromDeclarationOfExportNamedDeclaration(node.declaration),
+  ...getIdentifiersFromSpecifiersOfExportNamedDeclaration(node.specifiers),
+];
+
+const getIdentifiersFromVariableDeclaration = (node: VariableDeclaration): Identifier[] =>
+  (node.declarations as VariableDeclarator[]).flatMap(n =>
+    getIdentifiersFromDestructuringPattern(n.id),
+  );
+
+// class
+export class ESTreeParser {
+  private _results: Node[];
+
+  constructor(node: Node) {
+    this._results = [node];
+  }
+
+  get results(): Node[] {
+    return this._results;
+  }
+
+  getExportNamedDeclarationfromProgram(): ESTreeParser {
+    this._results = this._results
+      .filter((result): result is Program => result.type === 'Program')
+      .flatMap(result => getExportNamedDeclarationfromProgram(result));
+
+    return this;
+  }
+
+  getIdentifiersFromExportNamedDeclaration(): ESTreeParser {
+    this._results = this._results
+      .filter(
+        (result): result is ExportNamedDeclaration => result.type === 'ExportNamedDeclaration',
+      )
+      .flatMap(result => getIdentifiersFromExportNamedDeclaration(result));
+
+    return this;
+  }
+}

--- a/tests/rules/named-export.test.ts
+++ b/tests/rules/named-export.test.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { RuleTester } from 'eslint';
 import { namedExport } from '#/rules/named-export';
 
@@ -77,6 +79,53 @@ ruleTesterES2015.run('named-export: single named export', namedExport, {
       code: 'export const rule = {}',
       filename: 'src/rules/index.js',
       errors: ['The export name must match the filename. You need to rename to Rules or rules.'],
+    },
+  ],
+});
+
+const ruleTesterTS2015 = new RuleTester({
+  parser: path.resolve(__dirname, '../../node_modules/@typescript-eslint/parser'),
+  parserOptions: { ecmaVersion: '2015', sourceType: 'module' },
+});
+
+ruleTesterTS2015.run('named-export(ts): default export', namedExport, {
+  valid: [
+    {
+      code: 'const module: number = 1; export default module;',
+      filename: 'module.ts',
+    },
+  ],
+  invalid: [],
+});
+
+ruleTesterTS2015.run('named-export(ts): multiple named export', namedExport, {
+  valid: [
+    {
+      code: "export const module1: number = 1; export const module2: string = 'string'",
+      filename: 'module.ts',
+    },
+    {
+      code: `const module1: any[] = [];
+const module2: { key: string } = { key: 'string' };
+export { module1, module2 }`,
+      filename: 'module.ts',
+    },
+  ],
+  invalid: [],
+});
+
+ruleTesterTS2015.run('named-export(ts): single named export', namedExport, {
+  valid: [
+    {
+      code: 'export type Empty = {}',
+      filename: 'empty.ts',
+    },
+  ],
+  invalid: [
+    {
+      code: 'export type Blank = {}',
+      filename: 'empty.ts',
+      errors: ['The export name must match the filename. You need to rename to Empty or empty.'],
     },
   ],
 });

--- a/tests/utils/estree-parser.test.ts
+++ b/tests/utils/estree-parser.test.ts
@@ -1,0 +1,133 @@
+import { parse } from '@typescript-eslint/typescript-estree';
+import { Program, ESTreeParser } from '#/utils/estree-parser';
+
+describe('ESTreeParser', () => {
+  const getParser = (node: Program) => new ESTreeParser(node);
+
+  describe('getExportNamedDeclarationfromProgram()', () => {
+    const subject = (statements: string) => {
+      const program = parse(statements) as Program;
+      const parser = getParser(program);
+      return parser.getExportNamedDeclarationfromProgram().results;
+    };
+
+    test('With empty statement', () => {
+      const statements = '';
+      expect(subject(statements)).toEqual([]);
+    });
+
+    test('With single const declaration statement', () => {
+      const statements = 'const num = 1';
+      expect(subject(statements)).toEqual([]);
+    });
+
+    test('With single export statement', () => {
+      const statements = 'export const num = 1';
+      expect(subject(statements)).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'ExportNamedDeclaration' })]),
+      );
+    });
+  });
+
+  describe('getIdentifiersFromExportNamedDeclaration()', () => {
+    const subject = (statements: string) => {
+      const program = parse(statements) as Program;
+      const parser = getParser(program);
+      return parser
+        .getExportNamedDeclarationfromProgram()
+        .getIdentifiersFromExportNamedDeclaration().results;
+    };
+
+    test('With empty statement', () => {
+      const statements = '';
+      expect(subject(statements)).toEqual([]);
+    });
+
+    test('With single const declaration statement', () => {
+      const statements = 'const num = 1';
+      expect(subject(statements)).toEqual([]);
+    });
+
+    test('With single export statement: const Literal', () => {
+      const statements = `
+        export const num = 'string'
+        const str = 'string'
+        export { str }
+      `;
+      expect(subject(statements)).toEqual([
+        expect.objectContaining({ type: 'Identifier', name: 'num' }),
+        expect.objectContaining({ type: 'Identifier', name: 'str' }),
+      ]);
+    });
+
+    test('With single export statement: const Array', () => {
+      const statements = `
+        export const array = [1, 2, 3]
+        export const [element, assignment = 1, ...rest] = array
+      `;
+      expect(subject(statements)).toEqual([
+        expect.objectContaining({ type: 'Identifier', name: 'array' }),
+        expect.objectContaining({ type: 'Identifier', name: 'element' }),
+        expect.objectContaining({ type: 'Identifier', name: 'assignment' }),
+        expect.objectContaining({ type: 'Identifier', name: 'rest' }),
+      ]);
+    });
+
+    test('With single export statement: const Object', () => {
+      const statements = `
+        export const object = {
+          key: 'value',
+          nested: {
+            key: 'value',
+          }
+        }
+
+        export const { key, assignment = 'assign', ...rest } = object
+        export const { key: alias } = object
+        export const { nested: { key: nestedAlias } } = object
+      `;
+      expect(subject(statements)).toEqual([
+        expect.objectContaining({ type: 'Identifier', name: 'object' }),
+        expect.objectContaining({ type: 'Identifier', name: 'key' }),
+        expect.objectContaining({ type: 'Identifier', name: 'assignment' }),
+        expect.objectContaining({ type: 'Identifier', name: 'rest' }),
+        expect.objectContaining({ type: 'Identifier', name: 'alias' }),
+        expect.objectContaining({ type: 'Identifier', name: 'nestedAlias' }),
+      ]);
+    });
+
+    test('With single export statement: class/enum/function/interface/type', () => {
+      const statements = `
+        export class c1 {}
+        export class c2 extends c1 {}
+        export enum e {
+          E1,
+        }
+        export function f1(): boolean { return true }
+        export declare function f2(arg: any): boolean
+        export interface i {
+          i: number
+        }
+        export declare module m {}
+        export type t = {
+          s: string
+        }
+      `;
+      expect(subject(statements)).toEqual([
+        expect.objectContaining({ type: 'Identifier', name: 'c1' }),
+        expect.objectContaining({ type: 'Identifier', name: 'c2' }),
+        expect.objectContaining({ type: 'Identifier', name: 'e' }),
+        expect.objectContaining({ type: 'Identifier', name: 'f1' }),
+        expect.objectContaining({ type: 'Identifier', name: 'f2' }),
+        expect.objectContaining({ type: 'Identifier', name: 'i' }),
+        expect.objectContaining({ type: 'Identifier', name: 'm' }),
+        expect.objectContaining({ type: 'Identifier', name: 't' }),
+      ]);
+    });
+
+    test('With single export statement: *', () => {
+      const statements = "import path from 'path'; export * from path.resolve('../../src/utils/')";
+      console.log(subject(statements));
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -649,7 +649,7 @@
     "@typescript-eslint/typescript-estree" "3.1.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@3.1.0":
+"@typescript-eslint/typescript-estree@3.1.0", "@typescript-eslint/typescript-estree@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.1.0.tgz#eaff52d31e615e05b894f8b9d2c3d8af152a5dd2"
   integrity sha512-+4nfYauqeQvK55PgFrmBWFVYb6IskLyOosYEmhH3mSVhfBp9AIJnjExdgDmKWoOBHRcPM8Ihfm2BFpZf0euUZQ==


### PR DESCRIPTION
Close: #26 