### PR TITLE
Bugfix/false positive detection of named export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## Bugfix
 * [#27](https://github.com/epaew/eslint-plugin-filenames-simple/pull/27) Fixed the behavior that ESLint execution fails
 when the lint target includes TypeScript notation and the rule `named-export` is enabled.
+* [#30](https://github.com/epaew/eslint-plugin-filenames-simple/pull/30)
+    * Fixed false positives when statement contains both default export and single named export.
+    * Fixed false positives when statement contains both all export (`export *`) and single named export.
 
 # 0.3.0
 ## Features

--- a/docs/rules/named-export.md
+++ b/docs/rules/named-export.md
@@ -27,6 +27,13 @@ This rule checks the export name is same as filename.
     const module2 = 2;
     export { module1, module2 };
     ```
+* module.js
+    ```javascript
+    // It is ignored when the file includes both default export and named export.
+    const module = 1;
+    export default module;
+    export const extraModule = { key: 'value' };
+    ```
 
 ### When the filename contains two or more words
 * my-class.js

--- a/src/rules/named-export.ts
+++ b/src/rules/named-export.ts
@@ -13,10 +13,20 @@ const fetchFilename = (context: Rule.RuleContext) => {
   return filename === 'index' && dirname !== '' ? dirname : filename;
 };
 
-const fetchTargets = (node: Program): Identifier[] =>
-  new ESTreeParser(node)
-    .getExportNamedDeclarationfromProgram()
-    .getIdentifiersFromExportNamedDeclaration().results as Identifier[];
+const fetchTargets = (node: Program): Identifier[] => {
+  const programParser = new ESTreeParser(node);
+
+  const exportAllDeclarations = programParser.getExportAllDeclarationsFromProgram().unwrap();
+  const exportDefaultDeclarations = programParser
+    .getExportDefaultDeclarationsFromProgram()
+    .unwrap();
+  if (exportAllDeclarations.length !== 0 || exportDefaultDeclarations.length !== 0) return [];
+
+  return programParser
+    .getExportNamedDeclarationsFromProgram()
+    .getIdentifiersFromExportNamedDeclaration()
+    .unwrap() as Identifier[];
+};
 
 export const namedExport: Rule.RuleModule = {
   meta: {

--- a/tests/rules/named-export.test.ts
+++ b/tests/rules/named-export.test.ts
@@ -35,6 +35,20 @@ ruleTesterES2015.run('named-export: multiple named export', namedExport, {
   invalid: [],
 });
 
+ruleTesterES2015.run('named-export: single named export with default/all export', namedExport, {
+  valid: [
+    {
+      code: "export const extraModule = 1; export default { key: 'value' }",
+      filename: 'module.js',
+    },
+    {
+      code: "export const extraModule = 1; export * from '.'",
+      filename: 'module.js',
+    },
+  ],
+  invalid: [],
+});
+
 ruleTesterES2015.run('named-export: single named export', namedExport, {
   valid: [
     {

--- a/tests/utils/estree-parser.test.ts
+++ b/tests/utils/estree-parser.test.ts
@@ -4,11 +4,61 @@ import { Program, ESTreeParser } from '#/utils/estree-parser';
 describe('ESTreeParser', () => {
   const getParser = (node: Program) => new ESTreeParser(node);
 
-  describe('getExportNamedDeclarationfromProgram()', () => {
+  describe('getExportAllDeclarationsFromProgram()', () => {
     const subject = (statements: string) => {
       const program = parse(statements) as Program;
       const parser = getParser(program);
-      return parser.getExportNamedDeclarationfromProgram().results;
+      return parser.getExportAllDeclarationsFromProgram().unwrap();
+    };
+
+    test('With empty statement', () => {
+      const statements = '';
+      expect(subject(statements)).toEqual([]);
+    });
+
+    test('With single const declaration statement', () => {
+      const statements = 'const num = 1';
+      expect(subject(statements)).toEqual([]);
+    });
+
+    test('With single export statement', () => {
+      const statements = "export * from '.'";
+      expect(subject(statements)).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'ExportAllDeclaration' })]),
+      );
+    });
+  });
+
+  describe('getExportDefaultDeclarationsFromProgram()', () => {
+    const subject = (statements: string) => {
+      const program = parse(statements) as Program;
+      const parser = getParser(program);
+      return parser.getExportDefaultDeclarationsFromProgram().unwrap();
+    };
+
+    test('With empty statement', () => {
+      const statements = '';
+      expect(subject(statements)).toEqual([]);
+    });
+
+    test('With single const declaration statement', () => {
+      const statements = 'const num = 1';
+      expect(subject(statements)).toEqual([]);
+    });
+
+    test('With single export statement', () => {
+      const statements = "export default { key: 'value' }";
+      expect(subject(statements)).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'ExportDefaultDeclaration' })]),
+      );
+    });
+  });
+
+  describe('getExportNamedDeclarationsFromProgram()', () => {
+    const subject = (statements: string) => {
+      const program = parse(statements) as Program;
+      const parser = getParser(program);
+      return parser.getExportNamedDeclarationsFromProgram().unwrap();
     };
 
     test('With empty statement', () => {
@@ -34,8 +84,9 @@ describe('ESTreeParser', () => {
       const program = parse(statements) as Program;
       const parser = getParser(program);
       return parser
-        .getExportNamedDeclarationfromProgram()
-        .getIdentifiersFromExportNamedDeclaration().results;
+        .getExportNamedDeclarationsFromProgram()
+        .getIdentifiersFromExportNamedDeclaration()
+        .unwrap();
     };
 
     test('With empty statement', () => {
@@ -123,11 +174,6 @@ describe('ESTreeParser', () => {
         expect.objectContaining({ type: 'Identifier', name: 'm' }),
         expect.objectContaining({ type: 'Identifier', name: 't' }),
       ]);
-    });
-
-    test('With single export statement: *', () => {
-      const statements = "import path from 'path'; export * from path.resolve('../../src/utils/')";
-      console.log(subject(statements));
     });
   });
 });


### PR DESCRIPTION
Fixed false positives when the lint target file contains both default export and named export.

## Examples
* module-default.js
    ```
    export default { key: 'value' }
    export const extraModule = 1
    ```
    * Expected behavior: no error
    * Actual behavior of v0.3.0: `The export name must match the filename.`

* module-all.js
    ```
    export * as NS from 'other-module'
    export const extraModule = 1
    ```
    * Expected behavior: no error
    * Actual behavior of v0.3.0: `The export name must match the filename.`
