### PR TITLE
Change where to get the dictionaries of the `pluralize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * [#12](https://github.com/epaew/eslint-plugin-filenames-simple/pull/12) Add new rule `pluralize`
 * [#37](https://github.com/epaew/eslint-plugin-filenames-simple/pull/37)
 Add options for the rule `named-export` to limit the filenames to which this rule applies.
+* [#38](https://github.com/epaew/eslint-plugin-filenames-simple/pull/38)
+Change where to get the dictionaries for the rule `pluralize`.
 
 # 0.3.1
 ## Bugfix

--- a/docs/rules/named-export.md
+++ b/docs/rules/named-export.md
@@ -104,3 +104,6 @@ Specify one of the following as the file naming convention to which this rule ap
     ```typescript
     export type ClassExpression = { id: Identifier }
     ```
+
+## See also
+* [settings/pluralize](../settings/pluralize.md)

--- a/docs/rules/pluralize.md
+++ b/docs/rules/pluralize.md
@@ -13,9 +13,6 @@ This rule ensures that filenames are plural (or singular).
       {
         "parentDir": "plural",
         "file": "singular"
-      },
-      {
-        "uncountable": ["water"]
       }
     ]
   }
@@ -30,16 +27,5 @@ Specify one of the following naming conventions for each `parentDir` or `file`.
 * singular
 * plural
 
-### dictionaries: (the second option)
-Specify the dictionary to pass to the `pluralize` library.  
-See also: https://github.com/blakeembrey/pluralize#usage
-
-#### Keys and examples
-* irregular: array of arguments for `pluralize.addIrregularRule()`
-  * e.g. `[["singular", "plural"], ["person", "people"]]`
-* plural: array of arguments for `pluralize.addPluralRule()`
-  * e.g. `[["plural", "singular"]]`
-* singular: array of arguments for `pluralize.addSingularRule()`
-  * e.g. `[["singular", "plural"]]`
-* uncountable: array of arguments for `pluralize.addUncountableRule()`
-  * e.g. `["uncountable", "water"]`
+## See also
+* [settings/pluralize](../settings/pluralize.md)

--- a/docs/settings/pluralize.md
+++ b/docs/settings/pluralize.md
@@ -1,0 +1,30 @@
+# filenames-simple/pluralize
+Specify the dictionary to pass to the `pluralize` library.  
+See also: https://github.com/blakeembrey/pluralize#usage
+
+## Acceptable keys
+* irregular: array of arguments for `pluralize.addIrregularRule()`
+* plural: array of arguments for `pluralize.addPluralRule()`
+* singular: array of arguments for `pluralize.addSingularRule()`
+* uncountable: array of arguments for `pluralize.addUncountableRule()`
+
+## Configuration example
+```json
+{
+  "plugins": [
+    "filenames-simple"
+  ],
+  "rules": {
+    "filenames-simple/named-export": ["error", "singular"],
+    "filenames-simple/pluralize": ["error", { "parentDir": "plural", "file": "singular" }]
+  },
+  "settings": {
+    "filenames-simple": {
+      "pluralize": {
+        "irregular": [["singular", "plural"], ["index", "indices"]],
+        "uncountable": ["water"]
+      }
+    }
+  }
+}
+```

--- a/src/rules/named-export.ts
+++ b/src/rules/named-export.ts
@@ -5,7 +5,7 @@ import '../utils/polyfill.node10';
 import { Identifier, Program, ESTreeParser } from '../utils/estree-parser';
 import { isSameName } from '../utils/is-same-name';
 import { presetCaseConverters } from '../utils/preset-case-converters';
-import { isValidName } from '../utils/pluralize';
+import { initPluralize, isValidName } from '../utils/pluralize';
 
 type Pluralize = 'always' | 'singular' | 'plural';
 
@@ -37,9 +37,11 @@ export const namedExport: Rule.RuleModule = {
     schema: [{ enum: ['always', 'singular', 'plural'] }],
   },
   create: context => {
+    initPluralize(context);
+    const pluralize: Pluralize = context.options[0] ?? 'always';
+
     return {
       Program: node => {
-        const pluralize: Pluralize = context.options[0] ?? 'always';
         const filename = fetchFilename(context);
 
         if (!(pluralize === 'always' || isValidName(filename, pluralize))) return;

--- a/src/rules/pluralize.ts
+++ b/src/rules/pluralize.ts
@@ -1,29 +1,11 @@
 import path from 'path';
 import { Rule } from 'eslint';
-import { correct, Dictionaries, isValidName, setDictionaries } from '../utils/pluralize';
+import { correct, initPluralize, isValidName } from '../utils/pluralize';
 
 type Rules = {
   parentDir?: 'singular' | 'plural';
   file?: 'singular' | 'plural';
 };
-type Options = {
-  dictionaries?: Dictionaries;
-  rules: Rules;
-};
-
-const irregular = {
-  type: 'array',
-  items: {
-    type: 'array',
-    items: [{ type: 'string' }, { type: 'string' }],
-    maxItems: 2,
-    minItems: 2,
-  },
-  minItems: 1,
-  uniqueItems: true,
-};
-const plural = irregular;
-const singular = irregular;
 
 const fetchFilename = (context: Rule.RuleContext): [string, string[]] => {
   const absolutePath = path.resolve(context.getFilename());
@@ -31,11 +13,6 @@ const fetchFilename = (context: Rule.RuleContext): [string, string[]] => {
   const filename = basename.split('.');
 
   return [dirname, filename];
-};
-
-const parseOptions = (context: Rule.RuleContext): Options => {
-  const [rules = {}, dictionaries = {}] = context.options;
-  return { rules, dictionaries };
 };
 
 export const pluralize: Rule.RuleModule = {
@@ -50,26 +27,11 @@ export const pluralize: Rule.RuleModule = {
         },
         minProperties: 1,
       },
-      {
-        type: 'object',
-        properties: {
-          irregular,
-          plural,
-          singular,
-          uncountable: {
-            type: 'array',
-            items: { type: 'string' },
-            minItems: 1,
-            uniqueItems: true,
-          },
-        },
-        minProperties: 1,
-      },
     ],
   },
   create: context => {
-    const { rules, dictionaries } = parseOptions(context);
-    dictionaries && setDictionaries(dictionaries);
+    initPluralize(context);
+    const rules: Rules = context.options[0] ?? {};
 
     return {
       Program: node => {

--- a/src/utils/pluralize.ts
+++ b/src/utils/pluralize.ts
@@ -1,6 +1,7 @@
+import { Rule } from 'eslint';
 import pluralize from 'pluralize';
 
-type Rule = 'singular' | 'plural';
+type PluralizeRule = 'singular' | 'plural';
 export type Dictionaries = {
   irregular?: [string, string][];
   plural?: [string, string][];
@@ -8,23 +9,10 @@ export type Dictionaries = {
   uncountable?: string[];
 };
 
-export const correct = (name: string, rule?: Rule) => {
-  const corrector = {
-    singular: pluralize.singular,
-    plural: pluralize.plural,
-  };
-  return rule ? corrector[rule](name) : name;
-};
+export const initPluralize = (context: Pick<Rule.RuleContext, 'settings'>) => {
+  const dictionaries: Dictionaries | undefined = context.settings?.['filenames-simple']?.pluralize;
+  if (!dictionaries) return;
 
-export const isValidName = (name: string, rule?: Rule) => {
-  const validator = {
-    singular: pluralize.isSingular,
-    plural: pluralize.isPlural,
-  };
-  return rule ? validator[rule](name) : true;
-};
-
-export const setDictionaries = (dictionaries: Dictionaries) => {
   const keys: Array<keyof Dictionaries> = ['irregular', 'plural', 'singular', 'uncountable'];
   const dictionarySetter = {
     irregular: ([singular, plural]: [string, string]) =>
@@ -41,4 +29,20 @@ export const setDictionaries = (dictionaries: Dictionaries) => {
     // @ts-ignore
     dictionaries[key] && dictionaries[key].forEach(dictionarySetter[key]);
   });
+};
+
+export const correct = (name: string, rule?: PluralizeRule) => {
+  const corrector = {
+    singular: pluralize.singular,
+    plural: pluralize.plural,
+  };
+  return rule ? corrector[rule](name) : name;
+};
+
+export const isValidName = (name: string, rule?: PluralizeRule) => {
+  const validator = {
+    singular: pluralize.isSingular,
+    plural: pluralize.isPlural,
+  };
+  return rule ? validator[rule](name) : true;
 };

--- a/tests/rules/pluralize.test.ts
+++ b/tests/rules/pluralize.test.ts
@@ -1,5 +1,6 @@
 import { RuleTester } from 'eslint';
 import { pluralize } from '#/rules/pluralize';
+import { Dictionaries } from '#/utils/pluralize';
 
 const ruleTester = new RuleTester();
 
@@ -39,24 +40,8 @@ ruleTester.run('pluralize', pluralize, {
       filename: 'src/controllers/indices.js',
       options: [{ parentDir: 'plural', file: 'plural' }],
     },
-    {
-      code: '',
-      filename: 'src/lib/index.js',
-      options: [
-        { parentDir: 'plural', file: 'singular' },
-        { irregular: [['person', 'people']], uncountable: ['lib'] },
-      ],
-    },
   ],
   invalid: [
-    {
-      code: '',
-      filename: 'src/controller/index.js',
-      options: [{ parentDir: 'plural', file: 'singular' }],
-      errors: [
-        'The filename must follow the pluralize rule. Should rename to controllers/index.js',
-      ],
-    },
     {
       code: '',
       filename: 'src/controller/index.js',
@@ -74,4 +59,20 @@ ruleTester.run('pluralize', pluralize, {
       ],
     },
   ],
+});
+
+const dictonaries: Dictionaries = { irregular: [['person', 'people']], uncountable: ['lib'] };
+const ruleTesterWithDictonaries = new RuleTester({
+  settings: { 'filenames-simple': { pluralize: dictonaries } },
+});
+
+ruleTesterWithDictonaries.run('pluralize', pluralize, {
+  valid: [
+    {
+      code: '',
+      filename: 'src/lib/index.js',
+      options: [{ parentDir: 'plural', file: 'singular' }],
+    },
+  ],
+  invalid: [],
 });

--- a/tests/utils/pluralize.test.ts
+++ b/tests/utils/pluralize.test.ts
@@ -1,3 +1,4 @@
+import { Rule } from 'eslint';
 import * as pluralize from '#/utils/pluralize';
 
 describe('pluralize.correct', () => {
@@ -62,28 +63,41 @@ describe('pluralize.isValidName', () => {
   });
 });
 
-describe('pluralize.setDictionaries', () => {
-  const dictionaries = {
-    irregular: [['regular', 'irregular']] as [string, string][],
-    plural: [['index', 'indexes']] as [string, string][],
-    singular: [['shoes', 'shoes']] as [string, string][],
-    uncountable: ['test'],
-  };
-  const subject = () => pluralize.setDictionaries(dictionaries);
+// NOTE: This test affects other tests because the instance of `pluralize` is a singleton.
+describe('pluralize.initPluralize', () => {
+  const subject = (context: Pick<Rule.RuleContext, 'settings'>) => pluralize.initPluralize(context);
 
-  it('returns true when the name is plural', () => {
-    // before setDictionaries()
-    expect(pluralize.correct('regular', 'plural')).toBe('regulars');
-    expect(pluralize.correct('index', 'plural')).toBe('indices');
-    expect(pluralize.correct('shoes', 'singular')).toBe('shoe');
-    expect(pluralize.correct('test', 'plural')).toBe('tests');
+  describe('when dictionaries are empty', () => {
+    const context = { settings: {} };
 
-    subject();
+    it('does not throw error', () => {
+      subject(context);
+    });
+  });
 
-    // after setDictionaries()
-    expect(pluralize.correct('regular', 'plural')).toBe('irregular');
-    expect(pluralize.correct('index', 'plural')).toBe('indexes');
-    expect(pluralize.correct('shoes', 'singular')).toBe('shoes');
-    expect(pluralize.correct('test', 'plural')).toBe('test');
+  describe('when dictionaries are present', () => {
+    const dictionaries = {
+      irregular: [['regular', 'irregular']] as [string, string][],
+      plural: [['index', 'indexes']] as [string, string][],
+      singular: [['shoes', 'shoes']] as [string, string][],
+      uncountable: ['test'],
+    };
+    const context = { settings: { 'filenames-simple': { pluralize: dictionaries } } };
+
+    it('set the dictionaries of pluralize', () => {
+      // before setDictionaries()
+      expect(pluralize.correct('regular', 'plural')).toBe('regulars');
+      expect(pluralize.correct('index', 'plural')).toBe('indices');
+      expect(pluralize.correct('shoes', 'singular')).toBe('shoe');
+      expect(pluralize.correct('test', 'plural')).toBe('tests');
+
+      subject(context);
+
+      // after setDictionaries()
+      expect(pluralize.correct('regular', 'plural')).toBe('irregular');
+      expect(pluralize.correct('index', 'plural')).toBe('indexes');
+      expect(pluralize.correct('shoes', 'singular')).toBe('shoes');
+      expect(pluralize.correct('test', 'plural')).toBe('test');
+    });
   });
 });


### PR DESCRIPTION
## Related issue numbers
--

## About the pull request
- before: get the dictionaries from `context.options`
- after: get the dictionaries from `context.settings.filenames-simple.pluralize`

## Additional context
Add any other context for this pull request here.
