### PR TITLE
Fixup the behavior of `splitName()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Bugfixes
 * [#156](https://github.com/epaew/eslint-plugin-filenames-simple/pull/156)
 False positives when exported name does not strictly follow PascalCase.
+* [#158](https://github.com/epaew/eslint-plugin-filenames-simple/pull/158)
+Fixup the behavior of utils/split-name when the specific PascalCased name is given.
 
 ## Others
 * [#51](https://github.com/epaew/eslint-plugin-filenames-simple/pull/51)

--- a/__tests__/utils/preset-rules.PascalCase.test.ts
+++ b/__tests__/utils/preset-rules.PascalCase.test.ts
@@ -62,7 +62,13 @@ describe('presetRules.PascalCase', () => {
     });
 
     test('should return same strings when name is PascalCase', () => {
-      expect(targetNames.pascalCase.map(subject)).toEqual(targetNames.pascalCase);
+      expect(targetNames.pascalCase.map(subject)).toEqual([
+        'PascalCase',
+        'ThreeOrMoreWordsIncludingPascalCase',
+        'Pascal0Case',
+        'PascalCase0',
+        'EcmaScript', // ECMAScript will fixed to EcmaScript..
+      ]);
     });
 
     test('should return pascalized strings when name is snake_case', () => {

--- a/__tests__/utils/preset-rules.camelCase.test.ts
+++ b/__tests__/utils/preset-rules.camelCase.test.ts
@@ -57,6 +57,7 @@ describe('presetRules.camelCase', () => {
         'threeOrMoreWordsIncludingPascalCase',
         'pascal0Case',
         'pascalCase0',
+        'ecmaScript',
       ]);
     });
 

--- a/__tests__/utils/preset-rules.kebab-case.test.ts
+++ b/__tests__/utils/preset-rules.kebab-case.test.ts
@@ -57,6 +57,7 @@ describe('presetRules.kebab-case', () => {
         'three-or-more-words-including-pascal-case',
         'pascal0-case',
         'pascal-case0',
+        'ecma-script',
       ]);
     });
 

--- a/__tests__/utils/preset-rules.snake_case.test.ts
+++ b/__tests__/utils/preset-rules.snake_case.test.ts
@@ -62,6 +62,7 @@ describe('presetRules.snake_case', () => {
         'three_or_more_words_including_pascal_case',
         'pascal0_case',
         'pascal_case0',
+        'ecma_script',
       ]);
     });
 

--- a/__tests__/utils/seeds.json
+++ b/__tests__/utils/seeds.json
@@ -21,7 +21,8 @@
     "PascalCase",
     "ThreeOrMoreWordsIncludingPascalCase",
     "Pascal0Case",
-    "PascalCase0"
+    "PascalCase0",
+    "ECMAScript"
   ],
   "snakeCase": [
     "snake_case",

--- a/__tests__/utils/split-name.test.ts
+++ b/__tests__/utils/split-name.test.ts
@@ -37,6 +37,7 @@ describe('Split name written in PascalCase', () => {
       ['three', 'or', 'more', 'words', 'including', 'pascal', 'case'],
       ['pascal0', 'case'],
       ['pascal', 'case0'],
+      ['ecma', 'script'],
     ]);
   });
 });

--- a/src/utils/split-name.ts
+++ b/src/utils/split-name.ts
@@ -4,7 +4,7 @@
 export const splitName = (name: string): string[] => {
   return name
     .replace(/_/g, '-')
-    .replace(/([a-z0-9])([A-Z])|([A-Z])([A-Z])(?:[a-z])/g, '$1-$2')
+    .replace(/([a-z0-9])([A-Z])|([A-Z])([A-Z])(?=[a-z])/g, '$1$3-$2$4')
     .toLowerCase()
     .split('-');
 };


### PR DESCRIPTION
## Related issue numbers
--

## About the pull request
Fixup the behavior of `splitName()` when the given name is specified in consecutive uppercase letters. (e.g. `ECMAScript`, `HTTPServer`, etc.)

## Additional context
Add any other context for this pull request here.
