### PR TITLE
Bugfix rules/named-export: False positive detection of ExportNamedDeclaration in TSModuleBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 ## Features
 ## Bugfixes
+* [#198](https://github.com/epaew/eslint-plugin-filenames-simple/pull/198)
+False positive detection of ExportNamedDeclaration in TSModuleBlock. (Mixed in [#196](https://github.com/epaew/eslint-plugin-filenames-simple/pull/196))
+
 ## Others
 * [#196](https://github.com/epaew/eslint-plugin-filenames-simple/pull/196)
 Refactor `rules/named-export` to use `context.getDeclaredVariables()`.

--- a/__tests__/rules/named-export.test.ts
+++ b/__tests__/rules/named-export.test.ts
@@ -352,6 +352,20 @@ describe('rules/named-export', () => {
           },
         ],
       });
+
+      ruleTester.run('single named export in module declaration', namedExport, {
+        valid: [
+          {
+            code: `
+              declare module 'espree' {
+                export function parse(code: string, options?: any): Node;
+              }
+            `,
+            filename: 'espree.d.ts',
+          },
+        ],
+        invalid: [],
+      });
     });
   });
 });

--- a/docs/rules/named-export.md
+++ b/docs/rules/named-export.md
@@ -105,5 +105,13 @@ Specify one of the following as the file naming convention to which this rule ap
     export type ClassExpression = { id: Identifier }
     ```
 
+#### NOTE: This rule skips the detection of named exports in TypeScript module blocks.
+* @types/espree.d.ts
+    ```typescript
+    declare module 'espree' {
+      export function parse(code: string, options?: any): Node;
+    }
+    ```
+
 ## See also
 * [settings/pluralize](../settings/pluralize.md)


### PR DESCRIPTION
## Related issue numbers

## About the pull request
The rule `named-export` reports the warning "The export name must match the filename. You need to rename to Espree or espree" with below case;

* `@types/espree.d.ts`
```typescript
/// <reference types="estree" />

declare module 'espree' {
  // eslint-disable-next-line @typescript-eslint/no-explicit-any
  export function parse(code: string, options?: any): Node;
}
```

But this behavior is not what I expected, so I fix it.

## Additional context
Add any other context for this pull request here.
