### PR TITLE
Feature: Add new rule: typescript-module-declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 ## Features
+* [#199](https://github.com/epaew/eslint-plugin-filenames-simple/pull/199)
+Add new rule `typescript-module-declaration`.
+
 ## Bugfixes
 * [#198](https://github.com/epaew/eslint-plugin-filenames-simple/pull/198)
 False positive detection of ExportNamedDeclaration in TSModuleBlock. (Mixed in [#196](https://github.com/epaew/eslint-plugin-filenames-simple/pull/196))

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This plugin is inspired by [eslint-plugin-filenames](https://github.com/selaux/e
 * [naming-convention](./docs/rules/naming-convention.md)
 * [no-index](./docs/rules/no-index.md)
 * [pluralize](./docs/rules/pluralize.md)
+* [typescript-module-declaration](./docs/rules/typescript-module-declaration.md)
 
 ## CHANGELOG
 [CHANGELOG](./CHANGELOG.md)

--- a/__tests__/rules/index.test.ts
+++ b/__tests__/rules/index.test.ts
@@ -3,7 +3,8 @@ import { fetchAllRuleNames } from '../test-utils/fetch-rule-names';
 import { rules } from '#/rules';
 
 describe('Must include all rules', () => {
-  const subject = (key: string) => typeof rules[key] !== 'undefined';
+  const subject = (key: string) =>
+    (rules as { [key: string]: unknown | undefined })[key] !== undefined;
 
   test(`should include all rules`, () => {
     expect(fetchAllRuleNames().every(subject)).toBeTruthy();

--- a/__tests__/rules/typescript-module-declaration.test.ts
+++ b/__tests__/rules/typescript-module-declaration.test.ts
@@ -1,0 +1,156 @@
+import path from 'path';
+
+import { TSESLint } from '@typescript-eslint/experimental-utils';
+
+import { typescriptModuleDeclaration } from '#/rules/typescript-module-declaration';
+
+describe('rules/typescript-module-declaration', () => {
+  const ruleTester = new TSESLint.RuleTester({
+    parser: path.resolve(__dirname, '../../node_modules/@typescript-eslint/parser'),
+    parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+  });
+
+  ruleTester.run(
+    'module declaration with string (without path separator)',
+    typescriptModuleDeclaration,
+    {
+      valid: [
+        {
+          code: `
+            declare module 'espree' {
+              export function parse(code: string, options?: any): Node;
+            }
+          `,
+          filename: 'espree.d.ts',
+        },
+        // https://www.typescriptlang.org/docs/handbook/modules.html#ambient-modules
+        {
+          code: `
+            declare module "url" {
+              export interface Url {
+                protocol?: string;
+                hostname?: string;
+                pathname?: string;
+              }
+
+              export function parse(
+                urlStr: string,
+                parseQueryString?,
+                slashesDenoteHost?
+              ): Url;
+            }
+
+            declare module "path" {
+              export function normalize(p: string): string;
+              export function join(...paths: any[]): string;
+              export var sep: string;
+            }
+          `,
+          filename: 'node.d.ts',
+        },
+      ],
+      invalid: [
+        {
+          code: `
+            declare module 'espree' {
+              export function parse(code: string, options?: any): Node;
+            }
+          `,
+          filename: 'estree.d.ts',
+          errors: [
+            {
+              messageId: 'invalidFilename',
+              data: { filename: 'espree.d.ts' },
+            },
+          ],
+        },
+      ],
+    },
+  );
+
+  ruleTester.run(
+    'module declaration with string (with path separator)',
+    typescriptModuleDeclaration,
+    {
+      valid: [
+        {
+          code: `
+            declare module 'dayjs/locale/*' {
+              namespace locale {
+                interface Locale extends ILocale {};
+              }
+
+              const locale: locale.Locale;
+
+              export default locale;
+            }
+          `,
+          filename: 'dayjs.d.ts',
+        },
+        {
+          code: "declare module 'dayjs/locale/*' {}",
+          filename: 'dayjs-locale.d.ts',
+        },
+        {
+          code: "declare module 'dayjs/locale/*' {}",
+          filename: 'dayjs/locale.d.ts',
+        },
+        {
+          code: "declare module 'dayjs/locale/*' {}",
+          filename: 'dayjs/locale/index.d.ts',
+        },
+      ],
+      invalid: [
+        {
+          code: "declare module 'dayjs/locale/*' {}",
+          filename: 'locale.d.ts',
+          errors: [
+            {
+              messageId: 'invalidFilename',
+              data: { filename: 'dayjs.d.ts' },
+            },
+          ],
+        },
+      ],
+    },
+  );
+
+  ruleTester.run(
+    'module declaration with string (with exclamation and wildcard)',
+    typescriptModuleDeclaration,
+    {
+      valid: [
+        // https://www.typescriptlang.org/docs/handbook/modules.html#wildcard-module-declarations
+        {
+          code: `
+            declare module "json!*" {
+              const value: any;
+              export default value;
+            }
+          `,
+          filename: 'json.d.ts',
+        },
+        {
+          code: `
+            declare module "*!text" {
+              const content: string;
+              export default content;
+            }
+          `,
+          filename: 'text.d.ts',
+        },
+      ],
+      invalid: [],
+    },
+  );
+
+  ruleTester.run('module declaration with variable', typescriptModuleDeclaration, {
+    valid: [
+      {
+        code: "import Dayjs from 'dayjs'; declare module Dayjs {}",
+        filename: 'dayjs.d.ts',
+      },
+    ],
+    invalid: [],
+  });
+});

--- a/docs/rules/typescript-module-declaration.md
+++ b/docs/rules/typescript-module-declaration.md
@@ -1,0 +1,85 @@
+# filenames-simple/typescript-module-declaration
+This rule checks the filename includes name of declared module.
+
+## Configuration example
+```json
+{
+  "plugins": [
+    "filenames-simple"
+  ],
+  "rules": {
+    "filenames-simple/typescript-module-declaration": "error"
+  }
+}
+```
+
+## Available options
+No options are provided.
+
+## Rule details
+### Basic
+* espree.d.ts
+    ```typescript
+    // OK
+    declare module 'espree' {
+      export function parse(code: string, options?: any): Node;
+    }
+    ```
+
+* eslint.d.ts
+    ```typescript
+    // NG: The filename does not include the declared module name. We recommend renaming it to `espree.d.ts`.',
+    declare module 'espree' {
+      export function parse(code: string, options?: any): Node;
+    }
+    ```
+
+* node.d.ts
+    ```typescript
+    // OK: More than two modules are declared in the target file.
+    // https://www.typescriptlang.org/docs/handbook/modules.html#ambient-modules
+    declare module "url" {
+      export interface Url {
+        protocol?: string;
+        hostname?: string;
+        pathname?: string;
+      }
+
+      export function parse(
+        urlStr: string,
+        parseQueryString?,
+        slashesDenoteHost?
+      ): Url;
+    }
+
+    declare module "path" {
+      export function normalize(p: string): string;
+      export function join(...paths: any[]): string;
+      export var sep: string;
+    }
+    ```
+
+### With path separator, wildcard
+* dayjs/locale/index.d.ts
+    ```typescript
+    // OK: The dirname includes the name of declared module.
+    declare module 'dayjs/locale/*' {
+      namespace locale {
+        interface Locale extends ILocale {};
+      }
+
+      const locale: locale.Locale;
+
+      export default locale;
+    }
+    ```
+
+* json.d.ts
+    ```typescript
+    // OK
+    // https://www.typescriptlang.org/docs/handbook/modules.html#wildcard-module-declarations
+    declare module "json!*" {
+      const value: any;
+      export default value;
+    }
+    ```

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/jest": "^26.0.15",
     "@types/node": "^14.14.9",
     "@types/pluralize": "^0.0.29",
-    "@typescript-eslint/typescript-estree": "^4.8.1",
+    "@typescript-eslint/experimental-utils": "^4.8.1",
     "eslint": "^7.13.0",
     "eslint-plugin-filenames-simple": "file:.",
     "glob": "^7.1.6",

--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -8,5 +8,6 @@ export const all: Linter.BaseConfig = {
     'filenames-simple/naming-convention': 'error',
     'filenames-simple/no-index': 'error',
     'filenames-simple/pluralize': ['error', { parentDir: 'plural', file: 'singular' }],
+    'filenames-simple/typescript-module-declaration': 'error',
   },
 };

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -8,6 +8,7 @@ export const recommended: Linter.BaseConfig = {
     'filenames-simple/naming-convention': 'error',
     'filenames-simple/no-index': 'off',
     'filenames-simple/pluralize': 'off',
+    'filenames-simple/typescript-module-declaration': 'error',
   },
 };
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,19 +1,17 @@
-import { Rule } from 'eslint';
-
 import { casing } from './casing';
 import { extname } from './extname';
 import { namedExport } from './named-export';
 import { namingConvention } from './naming-convention';
 import { noIndex } from './no-index';
 import { pluralize } from './pluralize';
+import { typescriptModuleDeclaration } from './typescript-module-declaration';
 
-type Rules = { [key: string]: Rule.RuleModule | undefined };
-
-export const rules: Rules = {
+export const rules = {
   casing, // NOTE: Deprecated, I will remove this at v1.0.0
   extname,
   'named-export': namedExport,
   'naming-convention': namingConvention,
   'no-index': noIndex,
   pluralize,
+  'typescript-module-declaration': typescriptModuleDeclaration,
 };

--- a/src/rules/named-export.ts
+++ b/src/rules/named-export.ts
@@ -2,7 +2,7 @@ import 'core-js/features/array/flat-map';
 
 import path from 'path';
 
-import { TSESTree } from '@typescript-eslint/typescript-estree';
+import { TSESTree } from '@typescript-eslint/experimental-utils';
 import { Rule } from 'eslint';
 import { ExportNamedDeclaration, Identifier } from 'estree';
 

--- a/src/rules/typescript-module-declaration.ts
+++ b/src/rules/typescript-module-declaration.ts
@@ -1,0 +1,51 @@
+import path from 'path';
+
+import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
+import { Rule } from 'eslint';
+
+const compareFilenameAndModuleName = (filename: string, moduleName: string): boolean =>
+  filename.includes(moduleName.toLowerCase());
+
+const getModuleName = (identifier: TSESTree.Literal | TSESTree.Identifier): string =>
+  identifier.type === 'Literal'
+    ? (identifier.value as string).split(new RegExp(`[${path.sep}*!]`))[0]
+    : identifier.name;
+
+const getAbsoluteFilename = (context: Pick<Rule.RuleContext, 'getFilename'>): string =>
+  path.resolve(context.getFilename());
+
+export const typescriptModuleDeclaration: TSESLint.RuleModule<'invalidFilename', []> = {
+  meta: {
+    type: 'suggestion',
+    messages: {
+      invalidFilename:
+        'The filename/dirname does not include the declared module name. We recommend renaming to `{{ filename }}`.',
+    },
+    schema: [],
+  },
+  create: context => {
+    let program: TSESTree.Program;
+    const moduleIdentifiers = new Set<TSESTree.Identifier | TSESTree.Literal>();
+
+    return {
+      Program: node => {
+        program = node;
+      },
+      TSModuleDeclaration: node => {
+        if (node.parent?.type === 'Program') moduleIdentifiers.add(node.id);
+      },
+      'Program:exit': () => {
+        if (moduleIdentifiers.size !== 1) return;
+        const moduleName = getModuleName([...moduleIdentifiers][0]);
+
+        if (!compareFilenameAndModuleName(getAbsoluteFilename(context), moduleName)) {
+          context.report({
+            node: program,
+            messageId: 'invalidFilename',
+            data: { filename: `${moduleName}.d.ts` },
+          });
+        }
+      },
+    };
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -692,7 +692,7 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.8.1", "@typescript-eslint/experimental-utils@^4.0.1":
+"@typescript-eslint/experimental-utils@4.8.1", "@typescript-eslint/experimental-utils@^4.0.1", "@typescript-eslint/experimental-utils@^4.8.1":
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.8.1.tgz#27275c20fa4336df99ebcf6195f7d7aa7aa9f22d"
   integrity sha512-WigyLn144R3+lGATXW4nNcDJ9JlTkG8YdBWHkDlN0lC3gUGtDi7Pe3h5GPvFKMcRz8KbZpm9FJV9NTW8CpRHpg==
@@ -727,7 +727,7 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.8.1.tgz#23829c73c5fc6f4fcd5346a7780b274f72fee222"
   integrity sha512-ave2a18x2Y25q5K05K/U3JQIe2Av4+TNi/2YuzyaXLAsDx6UZkz1boZ7nR/N6Wwae2PpudTZmHFXqu7faXfHmA==
 
-"@typescript-eslint/typescript-estree@4.8.1", "@typescript-eslint/typescript-estree@^4.8.1":
+"@typescript-eslint/typescript-estree@4.8.1":
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.8.1.tgz#7307e3f2c9e95df7daa8dc0a34b8c43b7ec0dd32"
   integrity sha512-bJ6Fn/6tW2g7WIkCWh3QRlaSU7CdUUK52shx36/J7T5oTQzANvi6raoTsbwGM11+7eBbeem8hCCKbyvAc0X3sQ==


### PR DESCRIPTION
## Related issue numbers

## About the pull request
This rule reports a message when the filename does not include the name of declared module in the file.

## Additional context
Add any other context for this pull request here.
