### PR TITLE
Bugfix: Message of the rules/named-export reports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Add new rule `typescript-module-declaration`.
 ## Bugfixes
 * [#198](https://github.com/epaew/eslint-plugin-filenames-simple/pull/198)
 False positive detection of ExportNamedDeclaration in TSModuleBlock. (Mixed in [#196](https://github.com/epaew/eslint-plugin-filenames-simple/pull/196))
+* [#200](https://github.com/epaew/eslint-plugin-filenames-simple/pull/200)
+Fix the message of the rule `named-export` reports.
 
 ## Others
 * [#196](https://github.com/epaew/eslint-plugin-filenames-simple/pull/196)

--- a/__tests__/rules/named-export.test.ts
+++ b/__tests__/rules/named-export.test.ts
@@ -140,76 +140,111 @@ describe('rules/named-export', () => {
         {
           code: 'const module = 1; export { module }',
           filename: 'mod.js',
-          errors: ['The export name must match the filename. You need to rename to Mod or mod.'],
+          errors: [
+            {
+              messageId: 'invalidFilename',
+              data: { filename: 'module', extname: 'js' },
+            },
+          ],
         },
         {
           code: 'const module = 1; export { module as mod }',
           filename: 'my-module.js',
           errors: [
-            'The export name must match the filename. You need to rename to MyModule or myModule.',
+            {
+              messageId: 'invalidFilename',
+              data: { filename: 'mod', extname: 'js' },
+            },
           ],
         },
         {
           code: 'export const rule = {}',
           filename: 'src/rules/index.js',
           errors: [
-            'The export name must match the filename. You need to rename to Rules or rules.',
+            {
+              messageId: 'invalidFilename',
+              data: { filename: 'rule', extname: 'js' },
+            },
           ],
         },
         {
           code: 'export function myFunction(params) { return params; }',
           filename: 'function.js',
           errors: [
-            'The export name must match the filename. You need to rename to Function or function.',
+            {
+              messageId: 'invalidFilename',
+              data: { filename: 'my-function', extname: 'js' },
+            },
           ],
         },
         {
           code: 'export const myFunction = function(params) { return params; }',
           filename: 'function.js',
           errors: [
-            'The export name must match the filename. You need to rename to Function or function.',
+            {
+              messageId: 'invalidFilename',
+              data: { filename: 'my-function', extname: 'js' },
+            },
           ],
         },
         {
           code: 'export const myFunction = function myFunction(params) { return params; }',
           filename: 'function.js',
           errors: [
-            'The export name must match the filename. You need to rename to Function or function.',
+            {
+              messageId: 'invalidFilename',
+              data: { filename: 'my-function', extname: 'js' },
+            },
           ],
         },
         {
           code: 'export const mySpecialFunction = params => { return params; }',
           filename: 'function.js',
           errors: [
-            'The export name must match the filename. You need to rename to Function or function.',
+            {
+              messageId: 'invalidFilename',
+              data: { filename: 'my-special-function', extname: 'js' },
+            },
           ],
         },
         {
           code: 'export class MyClass {}',
           filename: 'klass.js',
           errors: [
-            'The export name must match the filename. You need to rename to Klass or klass.',
+            {
+              messageId: 'invalidFilename',
+              data: { filename: 'my-class', extname: 'js' },
+            },
           ],
         },
         {
           code: 'export const MySpecialClass = class {}',
           filename: 'klass.js',
           errors: [
-            'The export name must match the filename. You need to rename to Klass or klass.',
+            {
+              messageId: 'invalidFilename',
+              data: { filename: 'my-special-class', extname: 'js' },
+            },
           ],
         },
         {
           code: 'export const MySpecialClass = class MyClass extends MyBaseClass {}',
           filename: 'klass.js',
           errors: [
-            'The export name must match the filename. You need to rename to Klass or klass.',
+            {
+              messageId: 'invalidFilename',
+              data: { filename: 'my-special-class', extname: 'js' },
+            },
           ],
         },
         {
           code: "export { linter } from './linter'",
           filename: 'linters/index.js',
           errors: [
-            'The export name must match the filename. You need to rename to Linters or linters.',
+            {
+              messageId: 'invalidFilename',
+              data: { filename: 'linter', extname: 'js' },
+            },
           ],
         },
       ],
@@ -242,7 +277,10 @@ describe('rules/named-export', () => {
             code: 'const { module, ...rest } = { module: 1 }; export { rest }',
             filename: 'module.js',
             errors: [
-              'The export name must match the filename. You need to rename to Module or module.',
+              {
+                messageId: 'invalidFilename',
+                data: { filename: 'rest', extname: 'js' },
+              },
             ],
           },
         ],
@@ -329,26 +367,40 @@ describe('rules/named-export', () => {
             code: 'export enum Role { Admin, Operator }',
             filename: 'user-role.ts',
             errors: [
-              'The export name must match the filename. You need to rename to UserRole or userRole.',
+              {
+                messageId: 'invalidFilename',
+                data: { filename: 'role', extname: 'ts' },
+              },
             ],
           },
           {
             code: 'export interface Person { name: string; }',
             filename: 'user.ts',
             errors: [
-              'The export name must match the filename. You need to rename to User or user.',
+              {
+                messageId: 'invalidFilename',
+                data: { filename: 'person', extname: 'ts' },
+              },
             ],
           },
           {
             code: "export module Module { const val: string = 'module.val'; }",
             filename: 'mod.ts',
-            errors: ['The export name must match the filename. You need to rename to Mod or mod.'],
+            errors: [
+              {
+                messageId: 'invalidFilename',
+                data: { filename: 'module', extname: 'ts' },
+              },
+            ],
           },
           {
             code: 'export type Blank = {}',
             filename: 'empty.ts',
             errors: [
-              'The export name must match the filename. You need to rename to Empty or empty.',
+              {
+                messageId: 'invalidFilename',
+                data: { filename: 'blank', extname: 'ts' },
+              },
             ],
           },
         ],

--- a/docs/rules/named-export.md
+++ b/docs/rules/named-export.md
@@ -30,11 +30,13 @@ Specify one of the following as the file naming convention to which this rule ap
 ### Basic
 * module.js
     ```javascript
-    export const module = 1; // OK
+    // OK
+    export const module = 1;
     ```
 * module.js
     ```javascript
-    export const mod = 1; // NG: You can use `module` or `Module` as export name.
+    // NG: You can use `mod.js` or `Mod.js` as filename.
+    export const mod = 1;
     ```
 
 * module.js
@@ -58,24 +60,25 @@ Specify one of the following as the file naming convention to which this rule ap
     export const extraModule = { key: 'value' };
     ```
 
-### When the filename contains two or more words
+### When the name of exported module contains two or more words
 * my-class.js
     ```javascript
     /*
-     * When the filename is written in kebab-case, camelCase or PascalCase,
-     * the export name can be written in `camelCase` or `PascalCase`
+     * When the name of exported module is written in camelCase or PascalCase,
+     * the filename can be written in `kebab-case`, `camelCase` or `PascalCase`
      */
     export class MyClass {}
     ```
 * myFunction.js
     ```javascript
-    export function myFunction() {} // `MyFunction()` is also OK.
+    // `my-function.js`, `MyFunction.js` is also OK.
+    export function myFunction() {}
     ```
 
 ### When the filename is `index.js` (`index.ts`)
 * src/rules/index.js
     ```javascript
-    // You can use parent directory name as export name.
+    // The rule checks the parent directory name with the name of exported module.
     export const rules = {};
     ```
 * src/config/index.js

--- a/src/rules/typescript-module-declaration.ts
+++ b/src/rules/typescript-module-declaration.ts
@@ -24,23 +24,20 @@ export const typescriptModuleDeclaration: TSESLint.RuleModule<'invalidFilename',
     schema: [],
   },
   create: context => {
-    let program: TSESTree.Program;
     const moduleIdentifiers = new Set<TSESTree.Identifier | TSESTree.Literal>();
 
     return {
-      Program: node => {
-        program = node;
-      },
       TSModuleDeclaration: node => {
         if (node.parent?.type === 'Program') moduleIdentifiers.add(node.id);
       },
       'Program:exit': () => {
         if (moduleIdentifiers.size !== 1) return;
-        const moduleName = getModuleName([...moduleIdentifiers][0]);
+        const moduleIdentifier = [...moduleIdentifiers][0];
+        const moduleName = getModuleName(moduleIdentifier);
 
         if (!compareFilenameAndModuleName(getAbsoluteFilename(context), moduleName)) {
           context.report({
-            node: program,
+            node: moduleIdentifier,
             messageId: 'invalidFilename',
             data: { filename: `${moduleName}.d.ts` },
           });


### PR DESCRIPTION
## Related issue numbers
--

## About the pull request
This plugin should check the filename. so I fix the message reported by rules/named-export.

* Before: "The export name must match the filename."
* After: "The filename/dirname does not match the exported module name."

## Additional context
Add any other context for this pull request here.
