### PR TITLE
Fixup filename and extension extraction to handle dotfile filenames

### DIFF
--- a/__tests__/rules/naming-convention.test.ts
+++ b/__tests__/rules/naming-convention.test.ts
@@ -9,6 +9,7 @@ ruleTester.run('naming-convention', namingConvention, {
     { code: '', filename: 'kebab-case.js' },
     { code: '', filename: 'index.js', options: [{ rule: 'PascalCase' }] },
     { code: '', filename: 'index.js', options: [{ rule: '[a-z]*' }] },
+    { code: '', filename: '.eslintrc.js', options: [{ excepts: ['\..+'] }] },
   ],
   invalid: [
     {
@@ -26,6 +27,11 @@ ruleTester.run('naming-convention', namingConvention, {
       filename: 'camelCase.js',
       options: [{ rule: '[a-z]*' }],
       errors: ["The filename must follow the rule: '[a-z]*'."],
+    },
+    {
+      code: '',
+      filename: '.dotfile',
+      errors: ["The filename must follow the rule: 'kebab-case'."],
     },
   ],
 });

--- a/src/rules/naming-convention.ts
+++ b/src/rules/naming-convention.ts
@@ -38,7 +38,7 @@ export const namingConvention: Rule.RuleModule = {
 
     return {
       Program: node => {
-        const [filename, ...rest] = path.basename(context.getFilename()).split('.');
+        const { name: filename, ext: extension } = path.parse(context.getFilename());
 
         if (filename.length === 0) {
           context.report({ node, message: 'The filename is empty' });
@@ -49,7 +49,7 @@ export const namingConvention: Rule.RuleModule = {
         const suggestion = (() => {
           try {
             const recommendedName = validator.getRecommendedName(filename);
-            return ` Should rename to ${[recommendedName, ...rest].join('.')}.`;
+            return ` Should rename to ${recommendedName}${extension}.`;
           } catch {
             // nothing to do
           }


### PR DESCRIPTION
## Related issue numbers

## About the pull request
Fixes filename and extension extraction so that dotfile filenames are handled.

## Additional context
It was previously throwing a 'The filename is empty' errors on dotfiles (e.g.: .eslintrc.js) and the 'excepts' option could not be used to suppress this because the filename length check validation occurs prior.